### PR TITLE
test(nats): removes unnecessary connection

### DIFF
--- a/nats/subscriber_test.go
+++ b/nats/subscriber_test.go
@@ -52,10 +52,6 @@ func TestSubscriberListenerSubscribe(t *testing.T) {
 
 	options.Url = sUrl
 
-	conn, err := nats.NewConn(context.Background())
-	assert.Nil(t, err)
-	defer conn.Close()
-
 	q, err := nats.NewSubscriberWithOptions(context.Background(), options)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
TestSubscriberListener was trying to open a connection on the default NATS port.
When removing this code the test was successful because nats.NewSubscriberWithOptions already opens a new connection on the test NATS server port.

Closes #3